### PR TITLE
remove references to svn, closes #2

### DIFF
--- a/custom_look.rst
+++ b/custom_look.rst
@@ -10,8 +10,8 @@ the sites created with the default css, so here we'll invoke T. S. Eliot's
 maxim "Talent imitates, but genius steals" and grab their css
 and part of their layout.  As before, you can either get the required
 files :file:`_static/default.css`, :file:`_templates/layout.html` and
-:file:`_static/logo.png` from the website or svn (see
-:ref:`fetching-the-data`).  Since I did a svn checkout before, I will
+:file:`_static/logo.png` from the website or git (see
+:ref:`fetching-the-data`).  Since I did a git clone before, I will
 just copy the stuff I need from there::
 
     home:~/tmp/sampledoc> cp ../sampledoc_tut/_static/default.css _static/

--- a/extensions.rst
+++ b/extensions.rst
@@ -12,7 +12,7 @@ sphinx doc directory, and there are other extensions written by other
 groups, eg numpy and ipython.  We're collecting these in this tutorial
 and showing you how to install and use them for your own project.
 First let's grab the python extension files from the :file:`sphinxext`
-directory from svn (see :ref:`fetching-the-data`), and install them in
+directory from git (see :ref:`fetching-the-data`), and install them in
 our :file:`sampledoc` project :file:`sphinxext` directory::
 
     home:~/tmp/sampledoc> mkdir sphinxext

--- a/getting_started.rst
+++ b/getting_started.rst
@@ -47,36 +47,29 @@ Fetching the data
 -----------------
 
 Now we will start to customize out docs.  Grab a couple of files from
-the `web site
-<http://matplotlib.svn.sourceforge.net/viewvc/matplotlib/trunk/sampledoc_tut/>`_
-or svn.  You will need :file:`getting_started.rst` and
+the `web site <https://github.com/matplotlib/sampledoc>`_
+or git.  You will need :file:`getting_started.rst` and
 :file:`_static/basic_screenshot.png`.  All of the files live in the
 "completed" version of this tutorial, but since this is a tutorial,
 we'll just grab them one at a time, so you can learn what needs to be
 changed where.  Since we have more files to come, I'm going to grab
-the whole svn directory and just copy the files I need over for now.
+the whole git directory and just copy the files I need over for now.
 First, I'll cd up back into the directory containing my project, check
-out the "finished" product from svn, and then copy in just the files I
+out the "finished" product from git, and then copy in just the files I
 need into my :file:`sampledoc` directory::
 
   home:~/tmp/sampledoc> pwd
   /Users/jdhunter/tmp/sampledoc
   home:~/tmp/sampledoc> cd ..
-  home:~/tmp> svn co https://matplotlib.svn.sourceforge.net/svnroot/\
-  matplotlib/trunk/sampledoc_tut
-  A    sampledoc_tut/cheatsheet.rst
-  A    sampledoc_tut/_static
-  A    sampledoc_tut/_static/basic_screenshot.png
-  A    sampledoc_tut/conf.py
-  A    sampledoc_tut/Makefile
-  A    sampledoc_tut/_templates
-  A    sampledoc_tut/_build
-  A    sampledoc_tut/getting_started.rst
-  A    sampledoc_tut/index.rst
-  Checked out revision 7449.
-  home:~/tmp> cp sampledoc_tut/getting_started.rst sampledoc/
-  home:~/tmp> cp sampledoc_tut/_static/basic_screenshot.png \
-  sampledoc/_static/
+  home:~/tmp> git clone https://github.com/matplotlib/sampledoc.git tutorial
+  Cloning into 'tutorial'...
+  remote: Counting objects: 87, done.
+  remote: Compressing objects: 100% (43/43), done.
+  remote: Total 87 (delta 45), reused 83 (delta 41)
+  Unpacking objects: 100% (87/87), done.
+  Checking connectivity... done
+  home:~/tmp> cp tutorial/getting_started.rst sampledoc/
+  home:~/tmp> cp tutorial/_static/basic_screenshot.png sampledoc/_static/
 
 The last step is to modify :file:`index.rst` to include the
 :file:`getting_started.rst` file (be careful with the indentation, the

--- a/index.rst
+++ b/index.rst
@@ -14,8 +14,8 @@ more.  If you follow along the tutorial, you'll start with nothing and
 end up with this site -- it's the bootstrapping documentation tutorial
 that writes itself!
 
-The source code for this tutorial lives in mpl svn (see
-:ref:`fetching-the-data`) and you can grab a harcopy of the the
+The source code for this tutorial lives in mpl git (see
+:ref:`fetching-the-data`) and you can grab a hardcopy of the
 `sampledoc PDF <sampledoc.pdf>`_
 
 .. toctree::


### PR DESCRIPTION
The svn repo still works, but it's even more out of date than this one. Pinging @mdboom who knows how to push this to matplotlib.org
